### PR TITLE
feat(auth): foundation — Supabase SSR clients, config, RBAC, auth helpers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,11 @@
-NEXT_PUBLIC_API_URL=
-NEXT_PUBLIC_APP_NAME=AjiraNext
+# App
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_SITE_NAME=AjiraNext
+NEXT_PUBLIC_API_URL=http://localhost:8085/v1
+
+# Supabase — get these from your Supabase project dashboard
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+
+# Development helpers (optional — allows bypassing real auth in local dev)
+# MOCK_AUTH_ROLE=job_seeker

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     ]
   },
   "dependencies": {
+    "@supabase/ssr": "^0.10.2",
+    "@supabase/supabase-js": "^2.104.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@supabase/ssr':
+        specifier: ^0.10.2
+        version: 0.10.2(@supabase/supabase-js@2.104.0)
+      '@supabase/supabase-js':
+        specifier: ^2.104.0
+        version: 2.104.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -896,6 +902,38 @@ packages:
       typescript:
         optional: true
 
+  '@supabase/auth-js@2.104.0':
+    resolution: {integrity: sha512-Vs0ndL+s5an7rOmXtS/nbYnGXL8m+KXlCSrPIcw9bR96ma6qyLYILnE6syuM+rpDnf+Tg4PVNxNB2+oDwoy6mA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.104.0':
+    resolution: {integrity: sha512-O8EyEz/RT1kfWhyJNpVc/VbLeBsohHGBVif/CI83zoMB+Iul/t/NIekH1/7RsH6kuO+b2D4wJhfiaW8Qr47sRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.0':
+    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
+
+  '@supabase/postgrest-js@2.104.0':
+    resolution: {integrity: sha512-ynylEq6wduQEycj6pL3P+/yIfDQ+CTnBC5I6p+PzcAO2ybj9coAITVtMfboi+g/dacgMslN5MH73rXsRMB29+Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.104.0':
+    resolution: {integrity: sha512-9fUVDoTVAhn7a79+AmEx+asUlRtf2yBrji7TQckcKn/WK4hvAA9Lia9er+lnhuz3WNiF1x6kkA4x7bRCJrU+KA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/ssr@0.10.2':
+    resolution: {integrity: sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.102.1
+
+  '@supabase/storage-js@2.104.0':
+    resolution: {integrity: sha512-s2NHtuAWb9nldJ/fS62WnJE6edvCWn31rrO+FJKlAohs99qdVgtLegUReTU2H9WnZiQlVqaBtu386wt6/6lrRw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.104.0':
+    resolution: {integrity: sha512-hILwhIjCB53G31jlHUe73NDEmrXudcjcYlVRuvNfEhzf0gyFQaFf7j6rd1UGmYZkFMOg//DFE8Iy9ZbNEgosVw==}
+    engines: {node: '>=20.0.0'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1053,6 +1091,9 @@ packages:
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.59.0':
     resolution: {integrity: sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==}
@@ -1497,6 +1538,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1979,6 +2024,10 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -3822,6 +3871,51 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@supabase/auth-js@2.104.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.104.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.0': {}
+
+  '@supabase/postgrest-js@2.104.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.104.0':
+    dependencies:
+      '@supabase/phoenix': 0.4.0
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/ssr@0.10.2(@supabase/supabase-js@2.104.0)':
+    dependencies:
+      '@supabase/supabase-js': 2.104.0
+      cookie: 1.1.1
+
+  '@supabase/storage-js@2.104.0':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.104.0':
+    dependencies:
+      '@supabase/auth-js': 2.104.0
+      '@supabase/functions-js': 2.104.0
+      '@supabase/postgrest-js': 2.104.0
+      '@supabase/realtime-js': 2.104.0
+      '@supabase/storage-js': 2.104.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -3977,6 +4071,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/resolve@1.20.6': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.39
 
   '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4468,6 +4566,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5092,6 +5192,8 @@ snapshots:
   html-escaper@2.0.2: {}
 
   husky@9.1.7: {}
+
+  iceberg-js@0.8.1: {}
 
   ignore@5.3.2: {}
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,52 @@
+import { ROLES, type Role } from "./rbac";
+import { createClient } from "./supabase/server";
+
+/**
+ * Fetches the current user's role from Supabase.
+ * In development, can be overridden by MOCK_AUTH_ROLE env var.
+ */
+export async function getUserRole(): Promise<Role | null | undefined> {
+  // Allow mock role in development for faster testing
+  if (process.env.NODE_ENV === "development") {
+    const mockRole = process.env.MOCK_AUTH_ROLE as Role | undefined;
+    if (mockRole && Object.values(ROLES).includes(mockRole)) {
+      return mockRole;
+    }
+  }
+
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
+
+    if (error || !user) {
+      return null;
+    }
+
+    // Role is expected to be stored in user_metadata or set by a custom claim/trigger
+    const role = user.user_metadata?.role as Role | undefined;
+
+    if (role && Object.values(ROLES).includes(role)) {
+      return role;
+    }
+
+    // If logged in but no specific role, default to AUTHENTICATED
+    return ROLES.AUTHENTICATED;
+  } catch (err) {
+    console.error("Error fetching user role:", err);
+    return null;
+  }
+}
+
+/**
+ * Helper to get the full user object if needed.
+ */
+export async function getUser() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return user;
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,14 @@
+// src/lib/config.ts
+export const config = {
+  baseUrl: (
+    process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
+  ).replace(/\/$/, ""),
+  siteName: process.env.NEXT_PUBLIC_SITE_NAME ?? "AjiraNext",
+  apiUrl: (
+    process.env.NEXT_PUBLIC_API_URL || "http://localhost:8085/v1"
+  ).replace(/\/$/, ""),
+  supabase: {
+    url: process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
+    anonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "",
+  },
+} as const;

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -1,0 +1,32 @@
+import { config } from "./config";
+import { ROLES, type Role } from "./rbac";
+
+export type OnboardingRole = "job_seeker" | "employer";
+
+export function parseOnboardingRole(
+  value: string | null | undefined,
+): OnboardingRole | null {
+  if (value === "job_seeker" || value === "employer") {
+    return value;
+  }
+
+  return null;
+}
+
+export function getOnboardingRoleForSignup(role: Role): OnboardingRole {
+  return role === ROLES.EMPLOYER_OWNER ? "employer" : "job_seeker";
+}
+
+export async function syncOnboardingRole(
+  accessToken: string,
+  role: OnboardingRole,
+) {
+  return fetch(`${config.apiUrl}/onboarding/role`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ role }),
+  });
+}

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -1,0 +1,99 @@
+export const ROLES = {
+  // System roles
+  ADMIN_SUPER: "admin_super",
+  ADMIN_MODERATOR: "admin_moderator",
+  SUPPORT_LEAD: "support_lead",
+  SUPPORT_AGENT: "support_agent",
+  MARKETING_MANAGER: "marketing_manager",
+  BLOG_AUTHOR: "blog_author",
+  BLOG_EDITOR: "blog_editor",
+
+  // Company roles
+  EMPLOYER_OWNER: "employer_owner",
+  EMPLOYER_ADMIN: "employer_admin",
+  EMPLOYER_RECRUITER: "employer_recruiter",
+  EMPLOYER_HIRING_MANAGER: "employer_hiring_manager",
+  EMPLOYER_BILLING: "employer_billing",
+
+  // Job seeker role
+  JOB_SEEKER: "job_seeker",
+
+  // Special access
+  PUBLIC: "public",
+  AUTHENTICATED: "authenticated",
+} as const;
+
+export type Role = (typeof ROLES)[keyof typeof ROLES];
+
+export const PORTAL_ACCESS = {
+  JOB_SEEKER_PORTAL: [ROLES.JOB_SEEKER, ROLES.ADMIN_SUPER],
+  EMPLOYER_PORTAL: [
+    ROLES.EMPLOYER_OWNER,
+    ROLES.EMPLOYER_ADMIN,
+    ROLES.EMPLOYER_RECRUITER,
+    ROLES.EMPLOYER_HIRING_MANAGER,
+    ROLES.EMPLOYER_BILLING,
+    ROLES.ADMIN_SUPER,
+  ],
+  ADMIN_PORTAL: [
+    ROLES.ADMIN_MODERATOR,
+    ROLES.ADMIN_SUPER,
+    ROLES.BLOG_AUTHOR,
+    ROLES.BLOG_EDITOR,
+  ],
+  SUPPORT_PORTAL: [ROLES.SUPPORT_AGENT, ROLES.SUPPORT_LEAD, ROLES.ADMIN_SUPER],
+  MARKETING_PORTAL: [ROLES.MARKETING_MANAGER, ROLES.ADMIN_SUPER],
+} as const;
+
+export type PortalName = keyof typeof PORTAL_ACCESS;
+
+/**
+ * Returns the default portal path for a given role.
+ */
+export function getPortalForRole(role: Role | null | undefined): string {
+  if (!role) return "/";
+
+  if (
+    role === ROLES.ADMIN_SUPER ||
+    role === ROLES.ADMIN_MODERATOR ||
+    role === ROLES.BLOG_AUTHOR ||
+    role === ROLES.BLOG_EDITOR
+  ) {
+    return "/admin";
+  }
+
+  if (role.startsWith("employer_")) {
+    return "/employer";
+  }
+
+  if (role === ROLES.SUPPORT_AGENT || role === ROLES.SUPPORT_LEAD) {
+    return "/support";
+  }
+
+  if (role === ROLES.MARKETING_MANAGER) {
+    return "/marketing";
+  }
+
+  if (role === ROLES.JOB_SEEKER || role === ROLES.AUTHENTICATED) {
+    return "/seeker";
+  }
+
+  return "/";
+}
+
+export function hasRole(userRoles: Role[], allowedRoles: Role[]): boolean {
+  if (allowedRoles.includes(ROLES.PUBLIC)) return true;
+  // If required is AUTHENTICATED, user just needs some role (implying logged in)
+  // Assuming 'public' is not in userRoles for logged in users, or we handle it separately.
+  if (allowedRoles.includes(ROLES.AUTHENTICATED) && userRoles.length > 0)
+    return true;
+
+  return userRoles.some((role) => allowedRoles.includes(role));
+}
+
+export function canAccessPortal(
+  userRoles: Role[],
+  portal: PortalName,
+): boolean {
+  return hasRole(userRoles, [...PORTAL_ACCESS[portal]]);
+}

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,6 @@
+import { createBrowserClient } from "@supabase/ssr";
+import { config } from "../config";
+
+export function createClient() {
+  return createBrowserClient(config.supabase.url, config.supabase.anonKey);
+}

--- a/src/lib/supabase/index.ts
+++ b/src/lib/supabase/index.ts
@@ -1,0 +1,2 @@
+export { createClient as createServerClient } from "./server";
+export { createClient as createBrowserClient } from "./client";

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,26 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import { config } from "../config";
+
+export async function createClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient(config.supabase.url, config.supabase.anonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            cookieStore.set(name, value, options),
+          );
+        } catch {
+          // The `setAll` method was called from a Server Component.
+          // This can be ignored if you have middleware refreshing
+          // user sessions.
+        }
+      },
+    },
+  });
+}

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,31 @@
+import { config } from "./config";
+
+/**
+ * Validates a redirect URL to prevent open-redirect attacks.
+ * Only allows relative paths or URLs matching the application's base URL.
+ */
+export function validateRedirectUrl(
+  url: string | null | undefined,
+): string | null {
+  if (!url) return null;
+
+  try {
+    // Check if it's a relative URL (starts with / but not //)
+    if (url.startsWith("/") && !url.startsWith("//")) {
+      return url;
+    }
+
+    const targetUrl = new URL(url);
+    const baseUrl = new URL(config.baseUrl);
+
+    // Only allow if origins match
+    if (targetUrl.origin === baseUrl.origin) {
+      return targetUrl.pathname + targetUrl.search + targetUrl.hash;
+    }
+  } catch {
+    // If URL parsing fails, it's likely invalid or relative
+    // We already handled relative above, so this is just for safety
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- Installed `@supabase/supabase-js` and `@supabase/ssr` packages
- Created typed environment configuration in `src/lib/config.ts`
- Created Supabase SSR clients (`server.ts`, `client.ts`, `index.ts`)
- Added RBAC system with roles, portal access, and helper functions
- Added auth helpers (`getUserRole`, `getUser`) with dev mock support
- Added URL redirect validator to prevent open-redirect attacks
- Added onboarding role utilities and backend sync helper
- Closes #1, #2, #3
- Part of Epic #11 (Auth Infrastructure)

## Linked Issues

Closes #1
Closes #2
Closes #3
Part of #11 (Epic 1 — Auth Infrastructure)

## Files Changed

```
 .env.example               |  13 +++++-
 package.json               |   2 +
 pnpm-lock.yaml             | 102 +++++++++++++++++++++++++++++++++++++++++++++
 src/lib/auth.ts            |  52 +++++++++++++++++++++++
 src/lib/config.ts          |  14 +++++++
 src/lib/onboarding.ts      |  32 ++++++++++++++
 src/lib/rbac.ts            |  99 +++++++++++++++++++++++++++++++++++++++++++
 src/lib/supabase/client.ts |   6 +++
 src/lib/supabase/index.ts  |   2 +
 src/lib/supabase/server.ts |  26 +++++++++++
 src/lib/url.ts             |  31 ++++++++++++++
 11 files changed, 377 insertions(+), 2 deletions(-)
```

## Gates (manual — Kimi Code has no CI yet)

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 warnings (4 pre-existing img warnings untouched)
- [x] `pnpm build` — success

## Verification

- [x] `@supabase/supabase-js` and `@supabase/ssr` installed and listed in `package.json`
- [x] `src/lib/config.ts` exports typed config with baseUrl, siteName, apiUrl, supabase credentials
- [x] `.env.example` documents all 5 required env vars
- [x] `src/lib/supabase/server.ts` uses `getAll`/`setAll` cookie API (v0.7+)
- [x] `src/lib/supabase/client.ts` creates browser client
- [x] `src/lib/rbac.ts` exports `ROLES`, `PORTAL_ACCESS`, `getPortalForRole`, `hasRole`, `canAccessPortal`
- [x] `getPortalForRole(ROLES.JOB_SEEKER)` returns `/seeker`
- [x] `src/lib/auth.ts` exports `getUserRole` with `MOCK_AUTH_ROLE` dev short-circuit
- [x] `src/lib/url.ts` validates relative paths and same-origin absolute URLs
- [x] `src/lib/onboarding.ts` exports `OnboardingRole`, `parseOnboardingRole`, `getOnboardingRoleForSignup`, `syncOnboardingRole`

## Notes for reviewer

- The second commit (config + supabase clients) was merged into the third commit due to a git lock race with lint-staged. All code changes are present.
- `syncOnboardingRole` uses `config.apiUrl` (falls back to `http://localhost:8085/v1`).