### PR TITLE
feat(auth): middleware for session refresh and route protection

### DIFF
--- a/src/lib/supabase/session.ts
+++ b/src/lib/supabase/session.ts
@@ -1,0 +1,80 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+import { config } from "../config";
+import { getPortalForRole } from "../rbac";
+
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({
+    request,
+  });
+
+  const supabase = createServerClient(
+    config.supabase.url,
+    config.supabase.anonKey,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value),
+          );
+          supabaseResponse = NextResponse.next({
+            request,
+          });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+
+  // IMPORTANT: Avoid writing any logic between createServerClient and
+  // supabase.auth.getUser(). A simple mistake can make it very hard to debug
+  // issues with users being randomly logged out.
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const isAuthPage =
+    request.nextUrl.pathname.startsWith("/auth") ||
+    request.nextUrl.pathname.startsWith("/onboarding");
+
+  const isPublicPath =
+    request.nextUrl.pathname === "/" ||
+    request.nextUrl.pathname.startsWith("/jobs") ||
+    request.nextUrl.pathname.startsWith("/for-employers") ||
+    request.nextUrl.pathname.startsWith("/pricing") ||
+    request.nextUrl.pathname.startsWith("/about") ||
+    request.nextUrl.pathname.startsWith("/contact") ||
+    request.nextUrl.pathname.startsWith("/blog") ||
+    request.nextUrl.pathname.startsWith("/help") ||
+    request.nextUrl.pathname.startsWith("/legal") ||
+    request.nextUrl.pathname.startsWith("/_next") ||
+    request.nextUrl.pathname.startsWith("/api/");
+
+  if (user && isAuthPage) {
+    // Authenticated users shouldn't see auth pages
+    const role = user.user_metadata?.role;
+    return NextResponse.redirect(new URL(getPortalForRole(role), request.url));
+  }
+
+  if (!user && !isAuthPage && !isPublicPath) {
+    // This is a protected route but no user is logged in.
+    // We redirect to auth with a returnUrl.
+    const url = request.nextUrl.clone();
+    url.pathname = "/auth";
+    url.searchParams.set("mode", "signin");
+    url.searchParams.set(
+      "returnUrl",
+      request.nextUrl.pathname + request.nextUrl.search,
+    );
+    return NextResponse.redirect(url);
+  }
+
+  // IMPORTANT: You *must* return the supabaseResponse object as it is.
+  return supabaseResponse;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,12 @@
+import { type NextRequest } from "next/server";
+import { updateSession } from "@/lib/supabase/session";
+
+export async function middleware(request: NextRequest) {
+  return await updateSession(request);
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};


### PR DESCRIPTION
## Summary

- Added `src/lib/supabase/session.ts` with `updateSession` helper using `@supabase/ssr` v0.7+ cookie API
- Added `src/middleware.ts` that refreshes sessions and redirects unauthenticated users from protected routes
- Public paths are whitelisted; auth pages redirect authenticated users to their role-based portal
- Closes #4
- Part of #11 (Epic 1 — Auth Infrastructure)

## Linked Issues

Closes #4
Part of #11 (Epic 1 — Auth Infrastructure)

## Gates

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm build` — success

## Verification

- [x] Middleware runs on all non-static routes
- [x] Unauthenticated user visiting `/seeker` → redirect to `/auth?mode=signin&returnUrl=/seeker`
- [x] Authenticated user visiting `/auth` → redirect to their portal
- [x] Public paths (`/`, `/jobs`, `/about`, etc.) are accessible without auth