### PR TITLE
feat(auth): protected route group layouts for portals

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+import { getUserRole } from "@/lib/auth";
+import { PORTAL_ACCESS } from "@/lib/rbac";
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const role = await getUserRole();
+
+  if (!role || !PORTAL_ACCESS.ADMIN_PORTAL.includes(role as never)) {
+    redirect("/auth?error=unauthorized");
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/(employer)/layout.tsx
+++ b/src/app/(employer)/layout.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+import { getUserRole } from "@/lib/auth";
+import { PORTAL_ACCESS } from "@/lib/rbac";
+
+export default async function EmployerLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const role = await getUserRole();
+
+  if (!role || !PORTAL_ACCESS.EMPLOYER_PORTAL.includes(role as never)) {
+    redirect("/auth?error=unauthorized");
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/(job-seeker)/layout.tsx
+++ b/src/app/(job-seeker)/layout.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+import { getUserRole } from "@/lib/auth";
+import { PORTAL_ACCESS } from "@/lib/rbac";
+
+export default async function JobSeekerLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const role = await getUserRole();
+
+  if (!role || !PORTAL_ACCESS.JOB_SEEKER_PORTAL.includes(role as never)) {
+    redirect("/auth?error=unauthorized");
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary

- Added `src/app/(job-seeker)/layout.tsx` — gates `/seeker` routes to job_seeker and admin_super roles
- Added `src/app/(employer)/layout.tsx` — gates `/employer` routes to employer_* and admin_super roles
- Added `src/app/(admin)/layout.tsx` — gates `/admin` routes to admin_moderator, admin_super, blog_author, blog_editor roles
- Unauthorized users are redirected to `/auth?error=unauthorized`
- Closes #8
- Part of #11 (Epic 1 — Auth Infrastructure)

## Linked Issues

Closes #8
Part of #11 (Epic 1 — Auth Infrastructure)

## Files Changed

 src/app/(admin)/layout.tsx      | 17 +++++++++++++++++
 src/app/(employer)/layout.tsx   | 17 +++++++++++++++++
 src/app/(job-seeker)/layout.tsx | 17 +++++++++++++++++
 3 files changed, 51 insertions(+)

## Gates (manual — Kimi Code has no CI yet)

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 warnings (4 pre-existing img-element warnings unrelated to this change)
- [x] `pnpm build` — success

## Verification

- [x] Job seeker can access `/seeker` and child routes
- [x] Employer can access `/employer` and child routes
- [x] Admin can access `/admin` and child routes
- [x] Wrong-role user visiting `/seeker` → `/auth?error=unauthorized`
- [x] Unauthenticated user visiting `/seeker` → `/auth?mode=signin&returnUrl=/seeker` (via middleware)

## Notes for reviewer

The `PORTAL_ACCESS.*.includes(role as never)` cast is an intentional workaround for `readonly` tuple typing — removing it causes a TS error.