### PR TITLE
feat(auth): wire AuthForm and AuthPage to server actions

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -6,6 +6,22 @@ import { AuthForm } from "@/design-system/organisms/AuthForm";
 import { AuthSidebar } from "@/design-system/organisms/AuthSidebar";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState, useCallback } from "react";
+import {
+  login,
+  signup,
+  signInWithGoogle,
+  requestPasswordReset,
+} from "@/app/auth/actions";
+
+function mapAuthError(raw: string): string {
+  if (raw.includes("Invalid login credentials"))
+    return "Email or password is incorrect.";
+  if (raw.includes("Email not confirmed"))
+    return "Please confirm your email before signing in.";
+  if (raw.includes("User already registered"))
+    return "An account with this email already exists.";
+  return "Something went wrong. Please try again.";
+}
 
 function AuthPageContent() {
   const router = useRouter();
@@ -18,10 +34,22 @@ function AuthPageContent() {
   const [mode, setMode] = useState(initialMode);
   const [role, setRole] = useState(initialRole);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(() => {
+    const paramError = searchParams.get("error");
+    if (paramError === "unauthorized") {
+      return "You don't have permission to access that section.";
+    } else if (paramError === "oauth_callback_failed") {
+      return "Sign-in failed. Please try again.";
+    }
+    return null;
+  });
+  const [resetSent, setResetSent] = useState(false);
 
   const handleModeChange = useCallback(
     (newMode: "signin" | "signup" | "reset" | "otp") => {
       setMode(newMode as "signin" | "signup");
+      setError(null);
+      setResetSent(false);
       const params = new URLSearchParams(searchParams.toString());
       params.set("mode", newMode);
       router.replace(`/auth?${params.toString()}`, { scroll: false });
@@ -39,13 +67,25 @@ function AuthPageContent() {
     [router, searchParams],
   );
 
-  const handleSocialSignIn = useCallback((provider: "google" | "linkedin") => {
-    console.log("Social sign-in:", provider);
-    // TODO: Implement OAuth flow
-  }, []);
+  const handleSocialSignIn = useCallback(
+    async (provider: "google" | "linkedin") => {
+      if (provider === "linkedin") {
+        setError("LinkedIn sign-in is coming soon.");
+        return;
+      }
+      setError(null);
+      setLoading(true);
+      const onboardingRole = role === "employer" ? "employer" : "job_seeker";
+      const returnUrl = searchParams.get("returnUrl") ?? undefined;
+      await signInWithGoogle({ onboardingRole, returnUrl });
+      // Note: signInWithGoogle redirects on success, so code below only runs on error
+      setLoading(false);
+    },
+    [role, searchParams],
+  );
 
   const handleSubmit = useCallback(
-    (data: {
+    async (data: {
       email: string;
       password: string;
       fullName?: string;
@@ -53,12 +93,51 @@ function AuthPageContent() {
       otp?: string;
     }) => {
       setLoading(true);
+      setError(null);
+      setResetSent(false);
 
-      console.log("Auth submit:", { mode, ...data });
-      // TODO: Implement auth API call
-      setTimeout(() => setLoading(false), 1500);
+      const formData = new FormData();
+      formData.append("email", data.email);
+      formData.append("password", data.password);
+      if (data.fullName) formData.append("fullName", data.fullName);
+      if (data.role)
+        formData.append(
+          "role",
+          data.role === "employer" ? "employer_owner" : "job_seeker",
+        );
+      formData.append("returnUrl", searchParams.get("returnUrl") ?? "");
+
+      if (mode === "signin") {
+        const result = await login(formData);
+        if (result?.error) {
+          setError(mapAuthError(result.error));
+          setLoading(false);
+        }
+        // On success, login redirects — no further code needed
+      } else if (mode === "signup") {
+        const result = await signup(formData);
+        if (result?.error) {
+          setError(mapAuthError(result.error));
+          setLoading(false);
+        } else if (result?.success) {
+          setLoading(false);
+          setError("Check your email to confirm your account.");
+        }
+      } else if (mode === "reset") {
+        const result = await requestPasswordReset(formData);
+        if (result?.error) {
+          setError(mapAuthError(result.error));
+          setLoading(false);
+        } else {
+          setResetSent(true);
+          setLoading(false);
+        }
+      } else if (mode === "otp") {
+        setError("OTP sign-in is coming soon.");
+        setLoading(false);
+      }
     },
-    [mode],
+    [mode, searchParams],
   );
 
   return (
@@ -71,6 +150,8 @@ function AuthPageContent() {
         role={role}
         onRoleChange={handleRoleChange}
         loading={loading}
+        error={error}
+        resetSent={resetSent}
       />
     </AuthPageTemplate>
   );

--- a/src/design-system/organisms/AuthForm.tsx
+++ b/src/design-system/organisms/AuthForm.tsx
@@ -27,6 +27,8 @@ export interface AuthFormProps {
   role?: AuthRole;
   onRoleChange?: (role: AuthRole) => void;
   loading?: boolean;
+  error?: string | null;
+  resetSent?: boolean;
   className?: string;
 }
 
@@ -37,17 +39,20 @@ export interface AuthFormProps {
 const SocialButton: React.FC<{
   provider: "google" | "linkedin";
   onClick?: () => void;
-}> = ({ provider, onClick }) => {
+  disabled?: boolean;
+}> = ({ provider, onClick, disabled }) => {
   const isGoogle = provider === "google";
   return (
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
       className={cn(
         "flex items-center justify-center gap-2.5 w-full",
         "px-4 py-2.5 rounded-xl border border-border bg-card",
         "text-sm font-bold text-fg",
         "hover:border-primary transition-colors duration-150",
+        disabled && "opacity-50 cursor-not-allowed",
       )}
     >
       {isGoogle ? (
@@ -164,16 +169,16 @@ export const AuthForm: React.FC<AuthFormProps> = ({
   role = "seeker",
   onRoleChange,
   loading = false,
+  error,
+  resetSent = false,
   className,
 }) => {
   const [email, setEmail] = React.useState("");
   const [password, setPassword] = React.useState("");
   const [fullName, setFullName] = React.useState("");
   const [otp, setOtp] = React.useState("");
-  const [resetSent, setResetSent] = React.useState(false);
 
   const handleMode = (newMode: AuthMode) => {
-    setResetSent(false);
     onModeChange?.(newMode);
   };
 
@@ -269,6 +274,7 @@ export const AuthForm: React.FC<AuthFormProps> = ({
             <SocialButton
               provider="linkedin"
               onClick={() => onSocialSignIn?.("linkedin")}
+              disabled
             />
           </div>
           <Divider text="or continue with email" />
@@ -350,6 +356,16 @@ export const AuthForm: React.FC<AuthFormProps> = ({
               >
                 Forgot password?
               </button>
+            </div>
+          )}
+
+          {/* Error */}
+          {error && (
+            <div
+              role="alert"
+              className="bg-danger/10 text-danger text-sm font-bold p-3 rounded-xl"
+            >
+              {error}
             </div>
           )}
 


### PR DESCRIPTION
## Summary

- Added `error` prop to AuthForm for displaying auth errors
- Added `resetSent` prop to AuthForm for password reset flow
- Wired AuthPage to server actions: `login`, `signup`, `requestPasswordReset`, `signInWithGoogle`
- Added `mapAuthError` for friendly error messages
- Handles `error=unauthorized` and `error=oauth_callback_failed` query params
- Disabled LinkedIn button with "coming soon" message
- Closes #7
- Part of #11 (Epic 1 — Auth Infrastructure)

## Linked Issues

Closes #7
Part of #11 (Epic 1 — Auth Infrastructure)

## Gates

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm build` — success

## Verification

- [x] AuthForm accepts and displays `error` prop in `role="alert"` region
- [x] AuthForm accepts `resetSent` prop for password reset confirmation
- [x] Sign-in with bad credentials shows friendly inline error
- [x] Sign-up shows email confirmation message
- [x] Google sign-in triggers OAuth flow
- [x] `/auth?error=unauthorized` shows permission error
- [x] `/auth?error=oauth_callback_failed` shows sign-in failed error
- [x] No `console.log` auth stubs remain

## Notes for reviewer

- LinkedIn is disabled pending future implementation.
- Success messages (email confirmation, reset sent) reuse the error UI styling; a follow-up could add a dedicated success prop.