### PR TITLE
feat(auth): unit tests for url, rbac, onboarding utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "lint:fix": "eslint --fix .",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:unit": "vitest run --config vitest.unit.config.ts",
+    "test:unit:watch": "vitest --config vitest.unit.config.ts",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/src/lib/onboarding.test.ts
+++ b/src/lib/onboarding.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { parseOnboardingRole, getOnboardingRoleForSignup } from "./onboarding";
+import { ROLES } from "./rbac";
+
+describe("parseOnboardingRole", () => {
+  it("returns job_seeker for 'job_seeker'", () => {
+    expect(parseOnboardingRole("job_seeker")).toBe("job_seeker");
+  });
+
+  it("returns employer for 'employer'", () => {
+    expect(parseOnboardingRole("employer")).toBe("employer");
+  });
+
+  it("returns null for invalid values", () => {
+    expect(parseOnboardingRole("admin")).toBeNull();
+    expect(parseOnboardingRole("")).toBeNull();
+    expect(parseOnboardingRole(null)).toBeNull();
+    expect(parseOnboardingRole(undefined)).toBeNull();
+  });
+
+  it("is case-sensitive", () => {
+    expect(parseOnboardingRole("Job_Seeker")).toBeNull();
+    expect(parseOnboardingRole("EMPLOYER")).toBeNull();
+  });
+});
+
+describe("getOnboardingRoleForSignup", () => {
+  it("returns employer for EMPLOYER_OWNER", () => {
+    expect(getOnboardingRoleForSignup(ROLES.EMPLOYER_OWNER)).toBe("employer");
+  });
+
+  it("returns job_seeker for JOB_SEEKER", () => {
+    expect(getOnboardingRoleForSignup(ROLES.JOB_SEEKER)).toBe("job_seeker");
+  });
+
+  it("defaults to job_seeker for other roles", () => {
+    expect(getOnboardingRoleForSignup(ROLES.ADMIN_SUPER)).toBe("job_seeker");
+    expect(getOnboardingRoleForSignup(ROLES.EMPLOYER_ADMIN)).toBe("job_seeker");
+  });
+});

--- a/src/lib/rbac.test.ts
+++ b/src/lib/rbac.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { ROLES, getPortalForRole, hasRole, canAccessPortal } from "./rbac";
+
+describe("getPortalForRole", () => {
+  it("returns /seeker for job_seeker", () => {
+    expect(getPortalForRole(ROLES.JOB_SEEKER)).toBe("/seeker");
+  });
+
+  it("returns /employer for employer roles", () => {
+    expect(getPortalForRole(ROLES.EMPLOYER_OWNER)).toBe("/employer");
+    expect(getPortalForRole(ROLES.EMPLOYER_ADMIN)).toBe("/employer");
+    expect(getPortalForRole(ROLES.EMPLOYER_RECRUITER)).toBe("/employer");
+  });
+
+  it("returns /admin for admin roles", () => {
+    expect(getPortalForRole(ROLES.ADMIN_SUPER)).toBe("/admin");
+    expect(getPortalForRole(ROLES.ADMIN_MODERATOR)).toBe("/admin");
+  });
+
+  it("returns / for null or unknown roles", () => {
+    expect(getPortalForRole(null)).toBe("/");
+    expect(getPortalForRole(undefined)).toBe("/");
+    expect(
+      getPortalForRole("unknown" as (typeof ROLES)[keyof typeof ROLES]),
+    ).toBe("/");
+  });
+});
+
+describe("hasRole", () => {
+  it("returns true when PUBLIC is in allowed roles", () => {
+    expect(hasRole([ROLES.JOB_SEEKER], [ROLES.PUBLIC])).toBe(true);
+  });
+
+  it("returns true when AUTHENTICATED is required and user has any role", () => {
+    expect(hasRole([ROLES.JOB_SEEKER], [ROLES.AUTHENTICATED])).toBe(true);
+  });
+
+  it("returns false when user has no matching role", () => {
+    expect(hasRole([ROLES.JOB_SEEKER], [ROLES.EMPLOYER_OWNER])).toBe(false);
+  });
+
+  it("returns true when user has a matching role", () => {
+    expect(hasRole([ROLES.EMPLOYER_OWNER], [ROLES.EMPLOYER_OWNER])).toBe(true);
+  });
+});
+
+describe("canAccessPortal", () => {
+  it("allows job_seeker to access JOB_SEEKER_PORTAL", () => {
+    expect(canAccessPortal([ROLES.JOB_SEEKER], "JOB_SEEKER_PORTAL")).toBe(true);
+  });
+
+  it("allows admin_super to access any portal", () => {
+    expect(canAccessPortal([ROLES.ADMIN_SUPER], "JOB_SEEKER_PORTAL")).toBe(
+      true,
+    );
+    expect(canAccessPortal([ROLES.ADMIN_SUPER], "EMPLOYER_PORTAL")).toBe(true);
+    expect(canAccessPortal([ROLES.ADMIN_SUPER], "ADMIN_PORTAL")).toBe(true);
+  });
+
+  it("blocks job_seeker from employer portal", () => {
+    expect(canAccessPortal([ROLES.JOB_SEEKER], "EMPLOYER_PORTAL")).toBe(false);
+  });
+});

--- a/src/lib/url.test.ts
+++ b/src/lib/url.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+import { validateRedirectUrl } from "./url";
+
+// Mock config
+vi.mock("./config", () => ({
+  config: {
+    baseUrl: "https://ajiranext.example.com",
+  },
+}));
+
+describe("validateRedirectUrl", () => {
+  it("allows valid relative paths", () => {
+    expect(validateRedirectUrl("/profile")).toBe("/profile");
+    expect(validateRedirectUrl("/jobs?q=nextjs")).toBe("/jobs?q=nextjs");
+    expect(validateRedirectUrl("/")).toBe("/");
+  });
+
+  it("allows valid absolute paths with same origin", () => {
+    expect(validateRedirectUrl("https://ajiranext.example.com/profile")).toBe(
+      "/profile",
+    );
+  });
+
+  it("blocks external domains", () => {
+    expect(validateRedirectUrl("https://evil.com/phish")).toBeNull();
+    expect(validateRedirectUrl("//evil.com")).toBeNull();
+  });
+
+  it("blocks malformed URLs", () => {
+    expect(validateRedirectUrl("javascript:alert(1)")).toBeNull();
+    expect(validateRedirectUrl(null)).toBeNull();
+    expect(validateRedirectUrl("")).toBeNull();
+  });
+
+  describe("URL-encoded attacks", () => {
+    it("blocks URL-encoded double-slash (//evil.com)", () => {
+      expect(validateRedirectUrl("%2F%2Fevil.com")).toBeNull();
+    });
+
+    it("blocks URL-encoded colon-slash (%3A//evil.com)", () => {
+      expect(validateRedirectUrl("https%3A%2F%2Fevil.com")).toBeNull();
+    });
+  });
+
+  describe("protocol attacks", () => {
+    it("blocks data: URIs", () => {
+      expect(
+        validateRedirectUrl("data:text/html,<script>alert(1)</script>"),
+      ).toBeNull();
+      expect(validateRedirectUrl("DATA:text/html,xss")).toBeNull();
+    });
+
+    it("blocks javascript: protocol case variants", () => {
+      expect(validateRedirectUrl("JavaScript:alert(1)")).toBeNull();
+      expect(validateRedirectUrl("JAVASCRIPT:alert(1)")).toBeNull();
+    });
+  });
+
+  describe("backslash tricks", () => {
+    it("blocks backslash-based redirects", () => {
+      expect(validateRedirectUrl("\\/evil.com")).toBeNull();
+      expect(validateRedirectUrl("//evil.com\\@legit.com")).toBeNull();
+    });
+  });
+
+  describe("null bytes", () => {
+    it("passes through encoded null bytes in relative paths (no stripping)", () => {
+      expect(validateRedirectUrl("/good%00evil")).toBe("/good%00evil");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty string", () => {
+      expect(validateRedirectUrl("")).toBeNull();
+    });
+
+    it("handles undefined", () => {
+      expect(validateRedirectUrl(undefined)).toBeNull();
+    });
+
+    it("allows hash and query in relative paths", () => {
+      expect(validateRedirectUrl("/profile?tab=settings#section")).toBe(
+        "/profile?tab=settings#section",
+      );
+    });
+
+    it("blocks protocol-relative URLs (//evil.com/path)", () => {
+      expect(validateRedirectUrl("//evil.com/path")).toBeNull();
+    });
+  });
+});

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  resolve: {
+    alias: { "@": path.resolve(__dirname, "src") },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    env: {
+      NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+      NEXT_PUBLIC_API_URL: "http://localhost:8085/v1",
+      NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: "test-anon-key",
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Added `vitest.unit.config.ts` for Node-based unit tests (separate from Storybook browser tests)
- Added `test:unit` and `test:unit:watch` scripts to `package.json`
- Added `src/lib/url.test.ts` — 14 test cases for `validateRedirectUrl`
- Added `src/lib/rbac.test.ts` — 11 tests for `getPortalForRole`, `hasRole`, `canAccessPortal`
- Added `src/lib/onboarding.test.ts` — 7 tests for `parseOnboardingRole`, `getOnboardingRoleForSignup`
- Closes #10
- Part of #11 (Epic 1 — Auth Infrastructure)

## Linked Issues

Closes #10
Part of #11 (Epic 1 — Auth Infrastructure)

## Gates

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test:unit` — 32 passed (32)

## Verification

- [x] `validateRedirectUrl` correctly allows relative paths and same-origin URLs
- [x] `validateRedirectUrl` blocks external domains, protocol attacks, and malformed URLs
- [x] `getPortalForRole` returns correct paths for each role
- [x] `hasRole` correctly checks role membership
- [x] `canAccessPortal` enforces portal-specific access rules
- [x] `parseOnboardingRole` validates onboarding role strings
- [x] `getOnboardingRoleForSignup` maps signup roles correctly