### PR TITLE
fix(auth): reviewer swarm fixes — session cookies, RBAC, types, a11y, tests

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import { getUserRole } from "@/lib/auth";
-import { PORTAL_ACCESS } from "@/lib/rbac";
+import { canAccessPortal } from "@/lib/rbac";
+
+export const dynamic = "force-dynamic";
 
 export default async function AdminLayout({
   children,
@@ -9,7 +11,7 @@ export default async function AdminLayout({
 }) {
   const role = await getUserRole();
 
-  if (!role || !PORTAL_ACCESS.ADMIN_PORTAL.includes(role as never)) {
+  if (!role || !canAccessPortal([role], "ADMIN_PORTAL")) {
     redirect("/auth?error=unauthorized");
   }
 

--- a/src/app/(employer)/layout.tsx
+++ b/src/app/(employer)/layout.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import { getUserRole } from "@/lib/auth";
-import { PORTAL_ACCESS } from "@/lib/rbac";
+import { canAccessPortal } from "@/lib/rbac";
+
+export const dynamic = "force-dynamic";
 
 export default async function EmployerLayout({
   children,
@@ -9,7 +11,7 @@ export default async function EmployerLayout({
 }) {
   const role = await getUserRole();
 
-  if (!role || !PORTAL_ACCESS.EMPLOYER_PORTAL.includes(role as never)) {
+  if (!role || !canAccessPortal([role], "EMPLOYER_PORTAL")) {
     redirect("/auth?error=unauthorized");
   }
 

--- a/src/app/(job-seeker)/layout.tsx
+++ b/src/app/(job-seeker)/layout.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import { getUserRole } from "@/lib/auth";
-import { PORTAL_ACCESS } from "@/lib/rbac";
+import { canAccessPortal } from "@/lib/rbac";
+
+export const dynamic = "force-dynamic";
 
 export default async function JobSeekerLayout({
   children,
@@ -9,7 +11,7 @@ export default async function JobSeekerLayout({
 }) {
   const role = await getUserRole();
 
-  if (!role || !PORTAL_ACCESS.JOB_SEEKER_PORTAL.includes(role as never)) {
+  if (!role || !canAccessPortal([role], "JOB_SEEKER_PORTAL")) {
     redirect("/auth?error=unauthorized");
   }
 

--- a/src/app/auth/actions.ts
+++ b/src/app/auth/actions.ts
@@ -15,9 +15,12 @@ import { validateRedirectUrl } from "@/lib/url";
 export async function login(formData: FormData) {
   const supabase = await createClient();
 
-  const email = formData.get("email") as string;
-  const password = formData.get("password") as string;
+  const email = formData.get("email");
+  const password = formData.get("password");
   const returnUrl = formData.get("returnUrl") as string | null;
+  if (typeof email !== "string" || typeof password !== "string") {
+    return { error: "Invalid input" };
+  }
 
   const { data, error } = await supabase.auth.signInWithPassword({
     email,
@@ -25,7 +28,11 @@ export async function login(formData: FormData) {
   });
 
   if (error) {
-    return { error: error.message };
+    return { error: mapSafeError(error.message) };
+  }
+
+  if (!data.user.user_metadata?.role) {
+    redirect("/onboarding");
   }
 
   revalidatePath("/", "layout");
@@ -40,9 +47,12 @@ export async function login(formData: FormData) {
 export async function signup(formData: FormData) {
   const supabase = await createClient();
 
-  const email = formData.get("email") as string;
-  const password = formData.get("password") as string;
-  const rawRole = formData.get("role") as string;
+  const email = formData.get("email");
+  const password = formData.get("password");
+  const rawRole = formData.get("role");
+  if (typeof email !== "string" || typeof password !== "string") {
+    return { error: "Invalid input" };
+  }
   const role =
     rawRole === ROLES.JOB_SEEKER || rawRole === ROLES.EMPLOYER_OWNER
       ? rawRole
@@ -59,7 +69,7 @@ export async function signup(formData: FormData) {
   });
 
   if (error) {
-    return { error: error.message };
+    return { error: mapSafeError(error.message) };
   }
 
   revalidatePath("/", "layout");
@@ -133,7 +143,12 @@ export async function setOnboardingRole(
     return { error: "not_authenticated" };
   }
 
-  const response = await syncOnboardingRole(session.access_token, role);
+  let response: Response;
+  try {
+    response = await syncOnboardingRole(session.access_token, role);
+  } catch {
+    return { error: "sync_failed" };
+  }
 
   if (!response.ok) {
     if (response.status === 409) return { error: "role_already_set" };
@@ -160,29 +175,41 @@ export async function setOnboardingRole(
 
 export async function requestPasswordReset(formData: FormData) {
   const supabase = await createClient();
-  const email = formData.get("email") as string;
+  const email = formData.get("email");
 
-  const { error } = await supabase.auth.resetPasswordForEmail(email, {
+  if (typeof email !== "string") {
+    return { error: "Invalid input" };
+  }
+
+  await supabase.auth.resetPasswordForEmail(email, {
     redirectTo: `${config.baseUrl}/auth?mode=reset`,
   });
 
-  if (error) {
-    return { error: error.message };
-  }
-
+  // Always return generic success to prevent account enumeration
   return { success: true };
 }
 
 export async function updatePassword(formData: FormData) {
   const supabase = await createClient();
-  const password = formData.get("password") as string;
+  const password = formData.get("password");
+  if (typeof password !== "string") {
+    return { error: "Invalid input" };
+  }
 
   const { error } = await supabase.auth.updateUser({ password });
 
   if (error) {
-    return { error: error.message };
+    return { error: mapSafeError(error.message) };
   }
 
   revalidatePath("/", "layout");
   return { success: true };
+}
+
+function mapSafeError(raw: string): string {
+  if (raw.includes("Invalid login credentials"))
+    return "Invalid login credentials";
+  if (raw.includes("Email not confirmed"))
+    return "Please confirm your email before signing in.";
+  return "Something went wrong. Please try again.";
 }

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -7,6 +7,11 @@ import { validateRedirectUrl } from "@/lib/url";
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const { searchParams, origin } = new URL(request.url);
+  const providerError = searchParams.get("error");
+  if (providerError) {
+    return NextResponse.redirect(`${origin}/auth?error=oauth_denied`);
+  }
+
   const code = searchParams.get("code");
   const onboardingRole = parseOnboardingRole(
     searchParams.get("onboarding_role"),

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense } from "react";
 import { AuthPageTemplate } from "@/design-system/templates/AuthPageTemplate";
-import { AuthForm } from "@/design-system/organisms/AuthForm";
+import { AuthForm, AuthMode } from "@/design-system/organisms/AuthForm";
 import { AuthSidebar } from "@/design-system/organisms/AuthSidebar";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState, useCallback } from "react";
@@ -31,7 +31,7 @@ function AuthPageContent() {
   const initialRole =
     (searchParams.get("as") as "seeker" | "employer") ?? "seeker";
 
-  const [mode, setMode] = useState(initialMode);
+  const [mode, setMode] = useState<AuthMode>(initialMode);
   const [role, setRole] = useState(initialRole);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(() => {
@@ -46,8 +46,8 @@ function AuthPageContent() {
   const [resetSent, setResetSent] = useState(false);
 
   const handleModeChange = useCallback(
-    (newMode: "signin" | "signup" | "reset" | "otp") => {
-      setMode(newMode as "signin" | "signup");
+    (newMode: AuthMode) => {
+      setMode(newMode);
       setError(null);
       setResetSent(false);
       const params = new URLSearchParams(searchParams.toString());
@@ -77,8 +77,10 @@ function AuthPageContent() {
       setLoading(true);
       const onboardingRole = role === "employer" ? "employer" : "job_seeker";
       const returnUrl = searchParams.get("returnUrl") ?? undefined;
-      await signInWithGoogle({ onboardingRole, returnUrl });
-      // Note: signInWithGoogle redirects on success, so code below only runs on error
+      const result = await signInWithGoogle({ onboardingRole, returnUrl });
+      if (result?.error) {
+        setError(mapAuthError(result.error));
+      }
       setLoading(false);
     },
     [role, searchParams],

--- a/src/app/onboarding/OnboardingClient.tsx
+++ b/src/app/onboarding/OnboardingClient.tsx
@@ -34,7 +34,10 @@ export default function OnboardingClient() {
         setError("Failed to set up your account. Please try again.");
       }
 
-      setSelectedRole(null);
+      // Only clear selection on success; preserve for retry on error
+      if (!result?.error) {
+        setSelectedRole(null);
+      }
     });
   }
 
@@ -55,7 +58,7 @@ export default function OnboardingClient() {
             type="button"
             onClick={() => handleRoleSelect("job_seeker")}
             disabled={isPending}
-            className={`flex flex-col items-center gap-3 rounded-xl border-2 p-6 text-left transition-colors hover:bg-surface-raised disabled:cursor-not-allowed disabled:opacity-50 ${
+            className={`flex flex-col items-center gap-3 rounded-xl border-2 p-6 text-left transition-colors hover:bg-surface disabled:cursor-not-allowed disabled:opacity-50 ${
               selectedRole === "job_seeker"
                 ? "border-accent bg-accent/5"
                 : "border-border"
@@ -81,7 +84,7 @@ export default function OnboardingClient() {
             type="button"
             onClick={() => handleRoleSelect("employer")}
             disabled={isPending}
-            className={`flex flex-col items-center gap-3 rounded-xl border-2 p-6 text-left transition-colors hover:bg-surface-raised disabled:cursor-not-allowed disabled:opacity-50 ${
+            className={`flex flex-col items-center gap-3 rounded-xl border-2 p-6 text-left transition-colors hover:bg-surface disabled:cursor-not-allowed disabled:opacity-50 ${
               selectedRole === "employer"
                 ? "border-accent bg-accent/5"
                 : "border-border"

--- a/src/design-system/organisms/AuthForm.tsx
+++ b/src/design-system/organisms/AuthForm.tsx
@@ -52,6 +52,7 @@ const SocialButton: React.FC<{
         "px-4 py-2.5 rounded-xl border border-border bg-card",
         "text-sm font-bold text-fg",
         "hover:border-primary transition-colors duration-150",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
         disabled && "opacity-50 cursor-not-allowed",
       )}
     >
@@ -129,10 +130,12 @@ const RolePicker: React.FC<{
       onClick={() => onChange("seeker")}
       className={cn(
         "text-left p-4 rounded-xl border-2 transition-all duration-150",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
         role === "seeker"
-          ? "border-primary bg-primary/[0.06]"
+          ? "border-primary bg-primary/5"
           : "border-border hover:border-primary/40",
       )}
+      aria-pressed={role === "seeker"}
     >
       <b className="block text-sm text-fg">Job Seeker</b>
       <small className="block text-2xs text-fg-muted mt-0.5">
@@ -144,10 +147,12 @@ const RolePicker: React.FC<{
       onClick={() => onChange("employer")}
       className={cn(
         "text-left p-4 rounded-xl border-2 transition-all duration-150",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
         role === "employer"
-          ? "border-primary bg-primary/[0.06]"
+          ? "border-primary bg-primary/5"
           : "border-border hover:border-primary/40",
       )}
+      aria-pressed={role === "employer"}
     >
       <b className="block text-sm text-fg">Employer</b>
       <small className="block text-2xs text-fg-muted mt-0.5">
@@ -211,6 +216,7 @@ export const AuthForm: React.FC<AuthFormProps> = ({
             onClick={() => handleMode("signin")}
             className={cn(
               "px-5 py-2 rounded-full text-xs font-bold transition-all",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
               isSignIn
                 ? "bg-card text-fg shadow-xs"
                 : "text-fg-muted hover:text-fg",
@@ -223,6 +229,7 @@ export const AuthForm: React.FC<AuthFormProps> = ({
             onClick={() => handleMode("signup")}
             className={cn(
               "px-5 py-2 rounded-full text-xs font-bold transition-all",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
               isSignUp
                 ? "bg-card text-fg shadow-xs"
                 : "text-fg-muted hover:text-fg",
@@ -270,11 +277,12 @@ export const AuthForm: React.FC<AuthFormProps> = ({
             <SocialButton
               provider="google"
               onClick={() => onSocialSignIn?.("google")}
+              disabled={loading}
             />
             <SocialButton
               provider="linkedin"
               onClick={() => onSocialSignIn?.("linkedin")}
-              disabled
+              disabled={loading}
             />
           </div>
           <Divider text="or continue with email" />
@@ -352,7 +360,7 @@ export const AuthForm: React.FC<AuthFormProps> = ({
               <button
                 type="button"
                 onClick={() => handleMode("reset")}
-                className="text-xs font-bold text-primary hover:underline"
+                className="text-xs font-bold text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
               >
                 Forgot password?
               </button>
@@ -387,7 +395,7 @@ export const AuthForm: React.FC<AuthFormProps> = ({
         <button
           type="button"
           onClick={() => handleMode("signin")}
-          className="mt-4 text-sm font-bold text-primary hover:underline text-left"
+          className="mt-4 text-sm font-bold text-primary hover:underline text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
         >
           ← Back to sign in
         </button>
@@ -397,7 +405,7 @@ export const AuthForm: React.FC<AuthFormProps> = ({
         <button
           type="button"
           onClick={() => handleMode("signin")}
-          className="mt-4 text-sm font-bold text-primary hover:underline text-left"
+          className="mt-4 text-sm font-bold text-primary hover:underline text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
         >
           ← Back to sign in
         </button>

--- a/src/lib/onboarding.test.ts
+++ b/src/lib/onboarding.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { parseOnboardingRole, getOnboardingRoleForSignup } from "./onboarding";
 import { ROLES } from "./rbac";
 
@@ -36,5 +36,48 @@ describe("getOnboardingRoleForSignup", () => {
   it("defaults to job_seeker for other roles", () => {
     expect(getOnboardingRoleForSignup(ROLES.ADMIN_SUPER)).toBe("job_seeker");
     expect(getOnboardingRoleForSignup(ROLES.EMPLOYER_ADMIN)).toBe("job_seeker");
+  });
+
+  it("defaults to job_seeker for all non-employer roles", () => {
+    expect(getOnboardingRoleForSignup(ROLES.EMPLOYER_RECRUITER)).toBe(
+      "job_seeker",
+    );
+    expect(getOnboardingRoleForSignup(ROLES.SUPPORT_AGENT)).toBe("job_seeker");
+    expect(getOnboardingRoleForSignup(ROLES.MARKETING_MANAGER)).toBe(
+      "job_seeker",
+    );
+  });
+});
+
+describe("syncOnboardingRole", () => {
+  it("calls the onboarding API with correct payload", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    globalThis.fetch = fetchMock;
+
+    const { syncOnboardingRole } = await import("./onboarding");
+    await syncOnboardingRole("test-token", "job_seeker");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8085/v1/onboarding/role",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-token",
+        },
+        body: JSON.stringify({ role: "job_seeker" }),
+      },
+    );
+  });
+
+  it("returns the response on error", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    globalThis.fetch = fetchMock;
+
+    const { syncOnboardingRole } = await import("./onboarding");
+    const response = await syncOnboardingRole("test-token", "employer");
+
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe(503);
   });
 });

--- a/src/lib/rbac.test.ts
+++ b/src/lib/rbac.test.ts
@@ -6,15 +6,32 @@ describe("getPortalForRole", () => {
     expect(getPortalForRole(ROLES.JOB_SEEKER)).toBe("/seeker");
   });
 
+  it("returns /seeker for AUTHENTICATED", () => {
+    expect(getPortalForRole(ROLES.AUTHENTICATED)).toBe("/seeker");
+  });
+
   it("returns /employer for employer roles", () => {
     expect(getPortalForRole(ROLES.EMPLOYER_OWNER)).toBe("/employer");
     expect(getPortalForRole(ROLES.EMPLOYER_ADMIN)).toBe("/employer");
     expect(getPortalForRole(ROLES.EMPLOYER_RECRUITER)).toBe("/employer");
   });
 
+  it("returns /employer for all employer roles", () => {
+    expect(getPortalForRole(ROLES.EMPLOYER_HIRING_MANAGER)).toBe("/employer");
+    expect(getPortalForRole(ROLES.EMPLOYER_BILLING)).toBe("/employer");
+  });
+
   it("returns /admin for admin roles", () => {
     expect(getPortalForRole(ROLES.ADMIN_SUPER)).toBe("/admin");
     expect(getPortalForRole(ROLES.ADMIN_MODERATOR)).toBe("/admin");
+  });
+
+  it("returns /admin for blog and support roles", () => {
+    expect(getPortalForRole(ROLES.BLOG_AUTHOR)).toBe("/admin");
+    expect(getPortalForRole(ROLES.BLOG_EDITOR)).toBe("/admin");
+    expect(getPortalForRole(ROLES.SUPPORT_AGENT)).toBe("/admin");
+    expect(getPortalForRole(ROLES.SUPPORT_LEAD)).toBe("/admin");
+    expect(getPortalForRole(ROLES.MARKETING_MANAGER)).toBe("/admin");
   });
 
   it("returns / for null or unknown roles", () => {
@@ -42,6 +59,10 @@ describe("hasRole", () => {
   it("returns true when user has a matching role", () => {
     expect(hasRole([ROLES.EMPLOYER_OWNER], [ROLES.EMPLOYER_OWNER])).toBe(true);
   });
+
+  it("returns false for empty user roles with AUTHENTICATED requirement", () => {
+    expect(hasRole([], [ROLES.AUTHENTICATED])).toBe(false);
+  });
 });
 
 describe("canAccessPortal", () => {
@@ -57,7 +78,22 @@ describe("canAccessPortal", () => {
     expect(canAccessPortal([ROLES.ADMIN_SUPER], "ADMIN_PORTAL")).toBe(true);
   });
 
+  it("allows admin to access all portals", () => {
+    expect(canAccessPortal([ROLES.ADMIN_SUPER], "SUPPORT_PORTAL")).toBe(true);
+    expect(canAccessPortal([ROLES.ADMIN_SUPER], "MARKETING_PORTAL")).toBe(true);
+  });
+
   it("blocks job_seeker from employer portal", () => {
     expect(canAccessPortal([ROLES.JOB_SEEKER], "EMPLOYER_PORTAL")).toBe(false);
+  });
+
+  it("blocks empty roles", () => {
+    expect(canAccessPortal([], "JOB_SEEKER_PORTAL")).toBe(false);
+  });
+
+  it("handles multiple roles", () => {
+    expect(
+      canAccessPortal([ROLES.JOB_SEEKER, ROLES.ADMIN_SUPER], "EMPLOYER_PORTAL"),
+    ).toBe(true);
   });
 });

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -26,7 +26,7 @@ export const ROLES = {
 export type Role = (typeof ROLES)[keyof typeof ROLES];
 
 export const PORTAL_ACCESS = {
-  JOB_SEEKER_PORTAL: [ROLES.JOB_SEEKER, ROLES.ADMIN_SUPER],
+  JOB_SEEKER_PORTAL: [ROLES.JOB_SEEKER, ROLES.AUTHENTICATED, ROLES.ADMIN_SUPER],
   EMPLOYER_PORTAL: [
     ROLES.EMPLOYER_OWNER,
     ROLES.EMPLOYER_ADMIN,
@@ -66,12 +66,12 @@ export function getPortalForRole(role: Role | null | undefined): string {
     return "/employer";
   }
 
-  if (role === ROLES.SUPPORT_AGENT || role === ROLES.SUPPORT_LEAD) {
-    return "/support";
-  }
-
-  if (role === ROLES.MARKETING_MANAGER) {
-    return "/marketing";
+  if (
+    role === ROLES.SUPPORT_AGENT ||
+    role === ROLES.SUPPORT_LEAD ||
+    role === ROLES.MARKETING_MANAGER
+  ) {
+    return "/admin";
   }
 
   if (role === ROLES.JOB_SEEKER || role === ROLES.AUTHENTICATED) {

--- a/src/lib/supabase/session.ts
+++ b/src/lib/supabase/session.ts
@@ -53,13 +53,22 @@ export async function updateSession(request: NextRequest) {
     request.nextUrl.pathname.startsWith("/blog") ||
     request.nextUrl.pathname.startsWith("/help") ||
     request.nextUrl.pathname.startsWith("/legal") ||
-    request.nextUrl.pathname.startsWith("/_next") ||
-    request.nextUrl.pathname.startsWith("/api/");
+    request.nextUrl.pathname.startsWith("/_next");
 
-  if (user && isAuthPage) {
+  if (
+    user &&
+    isAuthPage &&
+    !request.nextUrl.pathname.startsWith("/onboarding")
+  ) {
     // Authenticated users shouldn't see auth pages
     const role = user.user_metadata?.role;
-    return NextResponse.redirect(new URL(getPortalForRole(role), request.url));
+    const redirectResponse = NextResponse.redirect(
+      new URL(getPortalForRole(role), request.url),
+    );
+    supabaseResponse.cookies.getAll().forEach(({ name, value, ...opts }) => {
+      redirectResponse.cookies.set(name, value, opts);
+    });
+    return redirectResponse;
   }
 
   if (!user && !isAuthPage && !isPublicPath) {

--- a/src/lib/url.test.ts
+++ b/src/lib/url.test.ts
@@ -88,4 +88,12 @@ describe("validateRedirectUrl", () => {
       expect(validateRedirectUrl("//evil.com/path")).toBeNull();
     });
   });
+
+  it("handles origin-only same-origin URL", () => {
+    expect(validateRedirectUrl("https://ajiranext.example.com")).toBe("/");
+  });
+
+  it("blocks whitespace-only strings", () => {
+    expect(validateRedirectUrl("   ")).toBeNull();
+  });
 });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,12 +1,12 @@
 import { type NextRequest } from "next/server";
 import { updateSession } from "@/lib/supabase/session";
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   return await updateSession(request);
 }
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    "/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };

--- a/vitest.unit.config.ts
+++ b/vitest.unit.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from "vitest/config";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig({
   resolve: {


### PR DESCRIPTION
## Summary

Consolidated fix PR addressing **14 critical findings** and **16 warnings** from the 6-agent reviewer swarm audit of Epic 1 (Auth Infrastructure).

## Reviewer Swarm Findings Addressed

### 🔴 Critical FAILs Fixed

| # | Issue | Fix |
|---|-------|-----|
| 1 | Middleware dropped refreshed session cookies on auth-page redirect | Copy `supabaseResponse.cookies` into redirect response before returning |
| 2 | Middleware blocked authenticated users from `/onboarding` | Added `!pathname.startsWith('/onboarding')` guard to auth-page redirect |
| 3 | Infinite redirect loop for `AUTHENTICATED` role users | Added `AUTHENTICATED` to `JOB_SEEKER_PORTAL`; `getPortalForRole` now routes support/marketing to `/admin` |
| 4 | `mode` state type too narrow in AuthPage | Widened to `AuthMode` imported from `AuthForm`; removed all `as` casts |
| 5 | Discarded `signInWithGoogle` error result | Now captures result and surfaces error via `setError()` |
| 6 | Unsafe `FormData` casts in all server actions | Added `typeof === "string"` validation; return `{ error: "Invalid input" }` on bad input |
| 7 | Unhandled network exception in `setOnboardingRole` | Wrapped `syncOnboardingRole()` in `try/catch`; returns `{ error: "sync_failed" }` |
| 8 | Broken retry button in OnboardingClient | Only reset `selectedRole` on success; preserve for retry on error |
| 9 | `as never` type bypass in all route group layouts | Replaced with `canAccessPortal([role], portalName)` |
| 10 | API routes universally treated as public paths | Removed `/api/` from `isPublicPath` in middleware |
| 11 | `src/middleware.ts` uses deprecated Next.js 16 convention | Renamed to `src/proxy.ts`; exported function renamed to `proxy` |
| 12 | Invalid Tailwind token `bg-surface-raised` | Replaced with `bg-surface` |
| 13 | Arbitrary value `bg-primary/[0.06]` | Replaced with `bg-primary/5` |
| 14 | `getPortalForRole` returned non-existent routes for support/marketing | Consolidated to `/admin` until dedicated portals exist |

### 🟡 WARNs Addressed

| # | Issue | Fix |
|---|-------|-----|
| 1 | Raw Supabase error messages leaked info to client | Added `mapSafeError()` helper; only whitelisted safe messages returned |
| 2 | No server-side input validation on auth forms | `typeof === "string"` guards on all `FormData` fields |
| 3 | Password reset flow could leak account existence via rate limits | Always returns generic `{ success: true }`; ignores Supabase error result |
| 4 | OAuth callback ignored provider error params | Now checks `searchParams.get("error")` and redirects to `?error=oauth_denied` |
| 5 | `AUTHENTICATED` role mapping gap | Added to `JOB_SEEKER_PORTAL` |
| 6 | Protected layouts lacked explicit dynamic config | Added `export const dynamic = "force-dynamic"` to all 3 portal layouts |
| 7 | Proxy matcher didn't exclude `/api/*` | Added `api` to negative lookahead in matcher regex |
| 8 | AuthForm used raw HTML instead of atoms | Partial fix: added focus-visible rings, aria-pressed, disabled states (full atom refactor deferred) |
| 9 | Missing visible focus states on custom interactive elements | Added `focus-visible:ring-*` to all custom buttons |
| 10 | Social buttons not disabled during loading | Pass `disabled={loading}` to both `SocialButton` instances |
| 11 | Role picker buttons lacked `aria-pressed` | Added `aria-pressed={role === "seeker"|"employer"}` |
| 12 | `hasRole()` / `canAccessPortal()` were dead code | All layouts now use `canAccessPortal()` |
| 13 | `login` action lacked role-existence check | Redirects to `/onboarding` if `user_metadata.role` is missing |
| 15 | Missing test coverage for RBAC roles, syncOnboardingRole, edge cases | Added 12 new tests; coverage expanded from 32 → **44 tests** |
| 16 | `__dirname` in `vitest.unit.config.ts` not ESM-safe | Replaced with `fileURLToPath(new URL(".", import.meta.url))` |

## Gates

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` (all modified files) — 0 errors, 0 warnings
- [x] `pnpm test:unit` — **44 passed (44)**
- [x] `pnpm build` — success

## Notes

- Support and marketing roles now route to `/admin` as a temporary measure until dedicated portals are built.
- Full AuthForm atom refactor (Heading, Paragraph, Eyebrow replacements) was deemed too large for this fix PR and is deferred as follow-up.
