### PR TITLE
fix(theme): suppress hydration warning on html element

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,6 +36,7 @@ export default function RootLayout({
       lang="en"
       className={`${inter.variable} h-full antialiased`}
       data-theme="dark"
+      suppressHydrationWarning
     >
       <body className="min-h-full flex flex-col font-sans">
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />


### PR DESCRIPTION
The inline theme script in ""<body>"" modifies ""document.documentElement.dataset.theme"" before React hydrates based on localStorage or prefers-color-scheme. This causes a hydration mismatch when the client theme (light) differs from the server default (dark). Adding ""suppressHydrationWarning"" to the ""<html>"" element is the standard documented fix for intentional theme-switching scripts.